### PR TITLE
Don't automatically name new pads based on search query

### DIFF
--- a/etherpad/src/static/js/pad_topbar.js
+++ b/etherpad/src/static/js/pad_topbar.js
@@ -146,10 +146,6 @@ var padtopbar = (function() {
       }
     }
 
-    createpadentry.on('input', function() {
-      $('#createpadentry-hidden').val(createpadentry.val());
-    });
-
     createpadentry.on('focus', function() {
       createpadentry.parent().addClass('search-focused');
     });

--- a/etherpad/src/themes/default/templates/header3.ejs
+++ b/etherpad/src/themes/default/templates/header3.ejs
@@ -83,8 +83,6 @@
           'data-modal': "#page-login-box",
           tooltip: N_('New Hackpad')
         }); %>
-        <input id="createpadentry-hidden" name="title"
-            value="<%=request.params.q%>" type="hidden"/>
       </form>
       <form id="createpadform2" action="/ep/pad/newpad">
         <div id="createpadbox">


### PR DESCRIPTION
BOO-YEAH @igorkofman 

![colbert-legolas-sword-juggling](https://cloud.githubusercontent.com/assets/55812/9369810/8cf1658c-4680-11e5-9698-de57e5582e5c.gif)

We observed that users frequently created new pads with titles that look
a lot like search queries.  This pollutes workspaces with empty pads.
Worse, these pads have titles optimized for search ranking since they
are named after popular queries, so search results quickly become fairly
useless.

We're not sure exactly what flow leads users to create these pads, but
we suspect that they're clicking the "new pad" button on the search
results page, which fills in a `title` query param based on the search
query.  This commit removes the auto-population of the `title` so the
new pad will be given the glorious default title of "Untitled."
