### PR TITLE
Remove 'create pad' row from search autocomplete

### DIFF
--- a/etherpad/src/static/js/pad_topbar.js
+++ b/etherpad/src/static/js/pad_topbar.js
@@ -25,7 +25,6 @@ var padtopbar = (function() {
       function preparse(hideSearchPage, numFound) {
         var val = padutils.escapeHtml(createpadentry.val());
         var rows = [];
-        var createUrl = "ep/pad/newpad?title=" + encodeURIComponent(val);
         if (val) {
           if (!hideSearchPage) {
             rows = rows.concat(preparseSearchPage());
@@ -34,18 +33,6 @@ var padtopbar = (function() {
           rows.push({
             data: ["<span class='ac-results-see-all ac-results-extra'>See all " + (numFound ? numFound : "") + " results <i class='icon-forward'></i></span>",
                    "ep/search/?q=" + encodeURIComponent(val)],
-            value: val,
-            result: val
-          });
-          /*rows.push({
-            data: ["<span class='ac-results-create-lbl ac-results-extra'>Create new pad</span>",
-                   createUrl],
-            value: val,
-            result: val
-          });*/
-          rows.push({
-            data: ["<span class='ac-results-create-val ac-results-extra'><span class='ac-results-create-val-newpad'><i class='icon-newpad'></i></span> " + val + "</span>",
-                   createUrl],
             value: val,
             result: val
           });


### PR DESCRIPTION
@igorkofman 

While this is intended to be a feature, I suspect people select it
accidentally more often than they do intentionally.  Selecting this row
issues a request to `/ep/pad/newpad?title=QUERY&r=POSITION`, where QUERY
is the query in the search bar and POSITION is the position of the row.
We saw this kind of URL in the request log for a user who accidentally
created a pad.  And anecdotally, I've personally selected this row by
accident.

Even if we remove this feature, it's relatively easy to create a new pad
by clicking the New Pad button, so hopefully we're not taking too much
away from users.
