### PR TITLE
Remove the CSP nonce from the CSP header

### DIFF
--- a/etherpad/src/etherpad/helpers.js
+++ b/etherpad/src/etherpad/helpers.js
@@ -650,5 +650,5 @@ function cspNonce() {
 }
 
 function getCSPPolicy() {
-  return _getCSPPolicy() + " 'nonce-" + cspNonce() + "';";
+  return _getCSPPolicy() + "';";
 }


### PR DESCRIPTION
When trying to load the homepage in Firefox 40, I get the following error in the console

```
Content Security Policy: Ignoring "'unsafe-inline'" within script-src: nonce-source or hash-source specified
```

This is due to `nonce-source` and `unsafe-inline` being included in the CSP header.

> Note this means that if you use a nonce/hash it's not possible to use
> javascript: urls or inline event handlers. It's as if the policy didn't
> have unsafe-inline at all. Probably worth throwing a warning on the web
> console if we encounter both unsafe-inline and a hash/nonce. It's not an
> error, but it might be a mistake. ("warning, 'unsafe-inline' is ignored
> when hash or nonce also used")
-- [Bug 1004703](https://bugzilla.mozilla.org/show_bug.cgi?id=1004703)

I've removed the CSP nonce to make everything work again.