### PR TITLE
Remove link to iOS app store.

### DIFF
--- a/etherpad/src/static/css/home_ejs.less
+++ b/etherpad/src/static/css/home_ejs.less
@@ -65,29 +65,6 @@ button.signin-button {
   padding: 15px 20px;
 }
 
-#app-store-badge {
-  vertical-aslign:middle;
-  margin-top:30px;
-  margin-right:10px;
-  display:block;
-  float:right;
-  z-index:1;
-  position:relative;
-}
-
-#app-store-badge span {
-  width:144px;
-  height:50px;
-  display: inline-block;
-  background-size: 100%;
-  background-repeat: no-repeat;
-  background-image: url("<%=helpers.cdn()%>/static/img/appstore-flat.png?v1");
-  @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dppx) {
-     background-image: url("<%=helpers.cdn()%>/static/img/appstore-flat@2x.png?v1");
-  }
-}
-
-
 #top-right-signin-button {
   font-size: 14px;
   padding: 10px 15px;

--- a/etherpad/src/themes/default/templates/main/home.ejs
+++ b/etherpad/src/themes/default/templates/main/home.ejs
@@ -52,12 +52,6 @@ limitations under the License. */ %>
       className: 'signin-button iphonehide',
       html: 'Sign up <em>or</em> Log in'
     }); %>
-
-    <div style="clear:both"/>
-
-    <a id="app-store-badge" href="https://itunes.apple.com/us/app/hackpad-for-ios/id789857184?ls=1&amp;mt=8"> <span class="appstore-logo"></span></a>
-    <style>
-    </style>
   </div>
 
 

--- a/etherpad/src/themes/default/templates/pro/pro_home.ejs
+++ b/etherpad/src/themes/default/templates/pro/pro_home.ejs
@@ -220,10 +220,6 @@ limitations under the License. */ %>
     </div-->
   <% } %>
 
-  <div style="margin-top:30px;">
-    <a href="https://itunes.apple.com/us/app/hackpad-for-ios/id789857184?ls=1&mt=8"><img src="/static/img/appstore.svg"/></a>
-  </div>
-
   <!-- admin interface -->
   <% if (linkToAdmin) { %>
   <div style="margin-top:30px; border-top: 1px solid #ccc; padding-top:10px">


### PR DESCRIPTION
Since the application is no longer available, don't show a link to it
anywhere on the homepage.