### PR TITLE
added missing animate.css dependencies

### DIFF
--- a/etherpad/src/static/css/animate/fadeInLeft.css
+++ b/etherpad/src/static/css/animate/fadeInLeft.css
@@ -1,0 +1,15 @@
+@keyframes fadeInLeft {
+  from {
+    opacity: 0;
+    transform: translate3d(-100%, 0, 0);
+  }
+
+  100% {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.fadeInLeft {
+  animation-name: fadeInLeft;
+}

--- a/etherpad/src/static/css/animate/fadeInRight.css
+++ b/etherpad/src/static/css/animate/fadeInRight.css
@@ -1,0 +1,15 @@
+@keyframes fadeInRight {
+  from {
+    opacity: 0;
+    transform: translate3d(100%, 0, 0);
+  }
+
+  100% {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.fadeInRight {
+  animation-name: fadeInRight;
+}

--- a/etherpad/src/static/css/animate/fadeOut.css
+++ b/etherpad/src/static/css/animate/fadeOut.css
@@ -1,0 +1,8 @@
+@keyframes fadeOut {
+  from {opacity: 1;}
+  100% {opacity: 0;}
+}
+
+.fadeOut {
+  animation-name: fadeOut;
+}


### PR DESCRIPTION
Address issue where some forms where not rendering because the following three static files were not present:

```
helpers.includeCss("animate/fadeInLeft.css");
helpers.includeCss("animate/fadeInRight.css");
helpers.includeCss("animate/fadeOut.css");
```
