### PR TITLE
Fix reference error

### DIFF
--- a/infrastructure/framework-src/modules/dispatch.js
+++ b/infrastructure/framework-src/modules/dispatch.js
@@ -20,6 +20,7 @@
 
 import("jsutils.eachProperty");
 import("stringutils");
+import("etherpad.log");
 
 jimport("java.lang.System.out.println");
 
@@ -171,4 +172,3 @@ function forward(module) {
     return served;
   };
 }
-


### PR DESCRIPTION
dispatch.js throws ReferenceError because it doesn’t import
“etherpad.log”