### PR TITLE
update run.sh to fix issue #9

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -24,7 +24,7 @@
 
 ETHERPADDIR="$(cd "$(dirname "$0")/.."; pwd)"
 source "$ETHERPADDIR/bin/exports.sh"
-source "$ETHERPADDIR/bin/ooffice.sh"
+
 
 PID_FILE="${ETHERPADDIR}/etherpad/data/etherpad.pid"
 echo $$ > $PID_FILE


### PR DESCRIPTION
in line 27 of run.sh , source "$ETHERPADDIR/bin/ooffice.sh" is getting set , but there is no oofice.sh in /etherpad/bin. this is getting setup from etherpad.properties later -so this line 27 is not needed