### PR TITLE
Don't add CSP header when disallowing framing.

### DIFF
--- a/infrastructure/framework-src/modules/global/response.js
+++ b/infrastructure/framework-src/modules/global/response.js
@@ -342,7 +342,6 @@ response.setGzip = function(gzip) {
 
 response.disallowFraming = function() {
   response.setHeader('X-Frame-Options', 'SAMEORIGIN');
-  response.addHeader('Content-Security-Policy', "frame-ancestors 'self'");
 }
 
 response.allowFraming = function() {


### PR DESCRIPTION
The CSP header is already added to every request, so we don't need to
add a second policy. I've confirmed that this fixes Hackpad in Firefox.

r? @devd