### PR TITLE
Pass the correct number of arguments to createNewAccount

### DIFF
--- a/etherpad/src/etherpad/pro/pro_accounts.js
+++ b/etherpad/src/etherpad/pro/pro_accounts.js
@@ -531,7 +531,13 @@ function isAccountSignedIn() {
           var email = ssoResult['email'];
           var pass = ssoResult['password'] || "";
           var name = ssoResult['fullname'] || "unnamed";
-          createNewAccount(null, name, email, pass, false, true);
+          createNewAccount(null, name, email, pass,
+            false, // isAdmin
+            true,  // skipValidation
+            null,  // fbid
+            false, // isDomainGuest
+            false  // isLinkedAccount
+          );
           user = getAccountByEmail(email, null);
         }
 


### PR DESCRIPTION
This fixes a bug where accounts wouldn't be created for single sign on users.