### PR TITLE
Make S3 region configurable.

### DIFF
--- a/etherpad/etc/etherpad.local.properties.tmpl
+++ b/etherpad/etc/etherpad.local.properties.tmpl
@@ -33,6 +33,7 @@ smtpPass = __smtp_password__
 awsUser = __aws_key_id__
 awsPass = __aws_secret__
 s3Bucket = __aws_attachments_bucket__
+s3Region = us-east-1
 solrHostPort = 127.0.0.1:9000
 solrOnly = false
 etherpad.syndicateChanges = true

--- a/etherpad/etc/etherpad.localdev-default.properties
+++ b/etherpad/etc/etherpad.localdev-default.properties
@@ -54,3 +54,4 @@ accountIdEncryptionKey = 0123456789abcdef
 collectionIdEncryptionKey = 0123456789abcdef
 welcomePadSourceId = WELCOMEPAD
 featureHelpPadId = FEATUREHELPPAD
+s3Region = us-east-1

--- a/infrastructure/framework-src/modules/s3.js
+++ b/infrastructure/framework-src/modules/s3.js
@@ -73,7 +73,6 @@ function getBytes(bucketName, keyName) {
   }
 }
 
-var AWS_REGION = 'us-east-1';
 var AWS_SERVICE = 's3';
 var AWS_REQUEST = 'aws4_request';
 /**
@@ -102,7 +101,7 @@ function _getS3Policy(domain, localPadId, userId, expirationDate, utcDateStr) {
       {"x-amz-credential":
           appjet.config.awsUser + "/" +
           utcDateStr + "/" +
-          AWS_REGION + "/" +
+          appjet.config.s3Region + "/" +
           AWS_SERVICE + "/" +
           AWS_REQUEST
       },
@@ -135,7 +134,7 @@ function getS3PolicyAndSig(domain, localPadId, userId) {
   var awsSecretKey = new java.lang.String("AWS4" + AWSSecretAccessKey).getBytes("UTF8");
 
   var dateKey = crypto.signString(awsSecretKey, utcDateStr);
-  var dateRegionKey = crypto.signString(dateKey, AWS_REGION);
+  var dateRegionKey = crypto.signString(dateKey, appjet.config.s3Region);
   var dateRegionServiceKey = crypto.signString(dateRegionKey, AWS_SERVICE);
   var signingKey = crypto.signString(dateRegionServiceKey, AWS_REQUEST);
   var signature = crypto.signString(signingKey, s3Policy);


### PR DESCRIPTION
The region was hard-coded to us-east-1, which is a non-starter for any
company not in that region.