### PR TITLE
Generate correct date for AMZ credentials.

### DIFF
--- a/infrastructure/framework-src/modules/s3.js
+++ b/infrastructure/framework-src/modules/s3.js
@@ -122,8 +122,8 @@ function getS3PolicyAndSig(domain, localPadId, userId) {
   var expirationDate = new Date();
   expirationDate.setDate(expirationDate.getDate() + 1);
 
-  function pad(n) { return n < 10 ? '0' + n : n }
-  var utcDateStr = expirationDate.getUTCFullYear() +
+  function pad(n) { return n < 10 ? '0' + n.toString() : n.toString() }
+  var utcDateStr = pad(expirationDate.getUTCFullYear()) +
       pad(expirationDate.getUTCMonth() + 1) +
       pad(expirationDate.getUTCDate());
 


### PR DESCRIPTION
The old function was adding numbers together instead of strings. Convert
the numbers to strings before addition.